### PR TITLE
自己紹介ページの追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>自己紹介ページ</title>
+    <style>
+        body {
+            font-family: 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            background-color: #f5f5f5;
+            color: #333;
+        }
+        
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: white;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            border-radius: 5px;
+            margin-top: 30px;
+        }
+        
+        header {
+            text-align: center;
+            padding: 20px 0;
+            border-bottom: 1px solid #eee;
+        }
+        
+        h1 {
+            color: #2c3e50;
+        }
+        
+        .profile-section {
+            padding: 20px 0;
+        }
+        
+        .profile-item {
+            margin-bottom: 15px;
+        }
+        
+        .profile-item h2 {
+            color: #3498db;
+            margin-bottom: 10px;
+        }
+        
+        footer {
+            text-align: center;
+            margin-top: 30px;
+            padding: 20px 0;
+            font-size: 0.9em;
+            color: #7f8c8d;
+            border-top: 1px solid #eee;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>プロフィール</h1>
+        </header>
+        
+        <section class="profile-section">
+            <div class="profile-item">
+                <h2>基本情報</h2>
+                <p>名前：山田太郎（仮名）</p>
+                <p>所在地：東京都</p>
+                <p>職業：ソフトウェアエンジニア</p>
+            </div>
+            
+            <div class="profile-item">
+                <h2>自己紹介</h2>
+                <p>
+                    はじめまして、山田太郎と申します。ソフトウェア開発の分野で5年の経験があります。
+                    主にWeb開発に携わっており、フロントエンドとバックエンドの両方の技術に興味を持っています。
+                    新しい技術を学ぶことが好きで、常に自己成長を目指しています。
+                </p>
+            </div>
+            
+            <div class="profile-item">
+                <h2>スキル</h2>
+                <ul>
+                    <li>プログラミング言語: JavaScript, Python, Ruby</li>
+                    <li>フレームワーク: React, Vue.js, Ruby on Rails</li>
+                    <li>データベース: MySQL, PostgreSQL, MongoDB</li>
+                    <li>その他: Git, Docker, AWS</li>
+                </ul>
+            </div>
+            
+            <div class="profile-item">
+                <h2>趣味</h2>
+                <p>
+                    読書、旅行、料理が趣味です。特に技術書を読むことで新しい知識を得ることが好きです。
+                    また、時間があるときは自然の中でハイキングをすることもあります。
+                </p>
+            </div>
+        </section>
+        
+        <footer>
+            <p>© 2025 山田太郎 - GitHubテストリポジトリ</p>
+        </footer>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
このPRでは、リポジトリに自己紹介用のindex.htmlを追加しています。

## 変更内容
- index.htmlファイルを追加
- シンプルなHTMLとCSSで自己紹介ページを作成
- レスポンシブデザインに対応

## スクリーンショット
プレビューのイメージ:
- ヘッダーに「プロフィール」タイトル
- 基本情報セクション
- 自己紹介文
- スキルリスト
- 趣味についての説明
- フッター部分

ご確認よろしくお願いします。